### PR TITLE
rk3399, rk3528, rk3566, rk3568, rk3588: Add update notes

### DIFF
--- a/patch-notes/RK3399_EN.md
+++ b/patch-notes/RK3399_EN.md
@@ -1,0 +1,85 @@
+# RK3399 Release Note
+
+## rk3399_bl32_v2.11.bin
+
+| Date       | file                  | Build commit | Severity |
+| ---------- | --------------------- | ------------ | -------- |
+| 2023-08-14 | rk3399_bl32_v2.11.bin | 44e25f04     | critical |
+
+### Fixed
+
+| Index | Severity  | Update                        | Issue description                                            | Issue source |
+| ----- | --------- | ----------------------------- | ------------------------------------------------------------ | ------------ |
+| 1     | critical  | Fix security vulnerabilities. | Hackers can exploit vulnerabilities to attack OPTEE OS.      | -            |
+| 2     | important | Fix memory leaks.             | Customer calls TEE_ DerivekeyFromHard may experience memory leakage issues. | 374096       |
+| 3     | important | Enable efuse dependent clock  | When program efuse, it relies on the saradc clock. Failure to turn on the clock may result in program efuse failure. |              |
+
+------
+
+## rk3399_usbplug_v1.30.bin
+
+| Date       | file                                | Build commit | Severity  |
+| ---------- | ----------------------------------- | ------------ | --------- |
+| 2023-05-31 | rk3399_usbplug_v1.30.bin | 8665a18a2   | important |
+
+### Fixed
+
+| Index | Severity  | Update                                                   | Issue description                                  | Issue source |
+| ----- | --------- | -------------------------------------------------------- | -------------------------------------------------- | ------------ |
+| 1     | important | Fixed sometime tool read efuse fail after efuse program. | Sometime tool read efuse fail after efuse program. | -            |
+
+------
+
+## rk3399_ddr_{666...933}MHz_v1.30.bin
+
+| Date       | file                                | Build commit | Severity  |
+| ---------- | ----------------------------------- | ------------ | --------- |
+| 2023-04-17 | rk3399_ddr_{666...933}MHz_v1.30.bin | aae4a89176   | important |
+
+### Fixed
+
+| Index | Severity  | Update                  | Issue description                               | Issue source |
+| ----- | --------- | ----------------------- | ----------------------------------------------- | ------------ |
+| 1     | important | Fixed LP3 reboot error. | When LP3 reboot, it will  stuck in ddr initial. | -            |
+
+------
+
+## rk3399_ddr_{666...933}MHz_v1.29.bin
+
+| Date       | file                                | Build commit | Severity  |
+| ---------- | ----------------------------------- | ------------ | --------- |
+| 2023-03-30 | rk3399_ddr_{666...933}MHz_v1.29.bin | 5b2c650      | important |
+
+### Fixed
+
+| Index | Severity  | Update                                                | Issue description                                            | Issue source |
+| ----- | --------- | ----------------------------------------------------- | ------------------------------------------------------------ | ------------ |
+| 1     | moderate  | Fixed single channel loop at "advanced training done" | When in single channel mode, it will loop at "advanced training done". | -            |
+| 2     | important | Fixed LP3 dbw detect bug                              | The dbw detect error when LP3                                | -            |
+
+------
+
+## rk3399_bl31_v1.36.elf
+
+| Date       | file                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-02-16 | rk3399_bl31_v1.36.elf | 8f40012ab    | important |
+
+### New
+
+1. Improve the stability of fiq-debugger.
+
+------
+
+## rk3399_ddr_{666...933}MHz_v1.28.bin
+
+| Date       | file                                | Build commit | Severity |
+| ---------- | :---------------------------------- | ------------ | -------- |
+| 2022-10-27 | rk3399_ddr_{666...933}MHz_v1.28.bin | c5af411      | moderate |
+
+### New
+
+1. Add support RK3399-T, RK3399-2T for DDR.
+
+------
+

--- a/patch-notes/RK3528_EN.md
+++ b/patch-notes/RK3528_EN.md
@@ -1,0 +1,444 @@
+# RK3528 Release Note
+
+## rk3528_ddr_1056MHz_{2L_PCB,4BIT_PCB_}v1.09.bin
+
+| Date       | File                                           | Build commit | Severity  |
+| ---------- | ---------------------------------------------- | ------------ | --------- |
+| 2024-01-30 | rk3528_ddr_1056MHz_{2L_PCB,4BIT_PCB_}v1.09.bin | 665f3e4817   | important |
+
+### New
+
+1. Support lp3 dram odt auto detect.
+2. Support vref training.
+
+### Fixed
+
+| Index | Severity  | Update                           | Issue description                                      | Issue source |
+| ----- | --------- | -------------------------------- | ------------------------------------------------------ | ------------ |
+| 1     | important | Fix CL err for byte mode lp4 in training. | It will error in training when used byte mode lp4.    | -            |
+| 2     | important | Fix lp4/lp4x 4L pcb config wrong.  | The signal of lp4/lp4x use 4L pcb is not in the best. | -            |
+
+------
+
+## rk3528_bl31_v1.17.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-12-21 | rk3528_bl31_v1.17.elf | eda1f5ce4    | important |
+
+### Fixed
+
+| Index | Severity  | Update                               | Issue description                                 | Issue source |
+| ----- | --------- | ------------------------------------ | ------------------------------------------------- | ------------ |
+| 1     | important | Fix cpu stall when video play back   | cpu will randomly stall when video playback       | -            |
+
+------
+
+## rk3528_spl_v1.05.bin
+
+| Date       | File                 | Build commit | Severity  |
+| ---------- | -------------------- | ------------ | --------- |
+| 2023-09-25 | rk3528_spl_v1.05.bin | e4e124926e   | important |
+
+### New
+
+1. Print and pass the firmware version number.
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                            | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------ |
+| 1     | important | Solve the issue that the backup image is not loaded when the SPL load or check u-boot.dtb fails | When u-boot.dtb of the first uboot.img is corrupted, SPL doesn't load the backup image. | -            |
+
+------
+
+## rk3528_bl32_v1.03.bin
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-08-29 | rk3528_bl32_v1.03.bin | b5340fd65    | important |
+
+### New
+
+1.  support oem otp key hardware read lock.
+2.  Pseudo random number seed will be set by default.
+3.  Supports read and write security flag interfaces.
+4.  Support check ta encryption key is written.
+5.  Support oem hdcp key.
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                 | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ------------------------------------------------- | ------------ |
+| 1     | important | Fixed hardware crypto probability crash issue after enabling dynamic memory | Error will be reported when using hardware crypto | -            |
+
+------
+
+## rk3528_ddr_1056MHz_{2L_PCB,4BIT_PCB_}v1.07.bin
+
+| Date       | File                                           | Build commit | Severity  |
+| ---------- | ---------------------------------------------- | ------------ | --------- |
+| 2023-08-04 | rk3528_ddr_1056MHz_{2L_PCB,4BIT_PCB_}v1.07.bin | 4fe5906c9d   | important |
+
+### New
+
+1. Support lp4/lp4x derate.
+2. Support modified CA de-skew by ddrbin_tool.
+
+### Fixed
+
+| Index | Severity  | Update                           | Issue description                                      | Issue source |
+| ----- | --------- | -------------------------------- | ------------------------------------------------------ | ------------ |
+| 1     | important | Fix per-bank-refresh enable bug. | Abnormal in OUT print when enable per-bank-refresh.    | -            |
+| 2     | important | Fix pageclose bug.               | The system error in dmc driver after enable pageclose. | -            |
+
+------
+
+## rk3528_bl31_v1.16.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-07-21 | rk3528_bl31_v1.16.elf | 7bfd76051    | important |
+
+### New
+
+1. Fix deadlock for soc monitor.
+
+------
+
+## rk3528_bl31_v1.15.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-07-17 | rk3528_bl31_v1.15.elf | d8ae91904    | important |
+
+### New
+
+1. Add support for rk3528A.
+
+------
+
+## rk3528_ddr_1056MHz_{2L_PCB,4BIT_PCB_}v1.06.bin
+
+| Date       | File                                           | Build commit | Severity  |
+| ---------- | ---------------------------------------------- | ------------ | --------- |
+| 2023-06-05 | rk3528_ddr_1056MHz_{2L_PCB,4BIT_PCB_}v1.06.bin | 1ab0bfbe2d   | important |
+
+### New
+
+1. Support modified CA de-skew by ddrbin_tool.
+
+------
+
+## rk3528_bl31_v1.14.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-05-19 | rk3528_bl31_v1.14.elf | 1b2124ab7    | important |
+
+### New
+
+1. Move  BL31 base to 0x80000.
+2. Support ddr frequency scale.
+
+------
+
+## rk3528_ddr_1056MHz_{2L_PCB,4BIT_PCB_}v1.05.bin
+
+| Date       | File                                           | Build commit | Severity  |
+| ---------- | ---------------------------------------------- | ------------ | --------- |
+| 2023-04-14 | rk3528_ddr_1056MHz_{2L_PCB,4BIT_PCB_}v1.05.bin | 2eef4a672d   | important |
+
+### New
+
+1. Add new ddrbin  for 4BIT PCB configurations.
+2. Add the configuration of LP3 CA skew.
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                            | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------ |
+| 1     | important | Fix the phase problem of DDR3 RAS in 2T mode.                | Abnormal RAS phase in DDR3 2T mode.                          | -            |
+| 2     | important | Fixed the abnormal ODT output problem in LP3 training under multi-rank. | The ODT output is abnormal when LP3 does cs1 write training under multi-rank. | -            |
+
+------
+
+## rk3528_bl32_v1.02.bin
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-04-12 | rk3528_bl32_v1.02.bin | c73fd5531    | important |
+
+### New
+
+1. Added crypto/trng/keylad module support.
+
+------
+
+## rk3528_bl31_v1.13.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-04-12 | rk3528_bl31_v1.13.elf | 642369d9b    | important |
+
+### New
+
+1. Modify pvtpll table for cpu and gpu.
+
+------
+
+## rk3528_spl_v1.04.bin
+
+| Date       | File                 | Build commit | Severity  |
+| ---------- | :----------------- - | ------------ | --------- |
+| 2023-04-11 | rk3528_spl_v1.04.bin | 0fbedd06     | important |
+
+### Fixed
+
+| Index | Severity  | Update                             | Issue description   | Issue source |
+| ----- | --------- | ---------------------------------- | ------------------- | ------------ |
+| 1     | important | Fix matrix 339M freq set/get error | EMMC transfer error | -            |
+
+------
+
+## rk3528_usbplug_v1.03.bin
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :----------------------- | ---------- | -------- |
+| 2023-04-08 | rk3528_usbplug_v1.03.bin | dbdfea79b  | important |
+
+### Fixed
+
+| Index | Severity  | Update                 | Issue description                  | Issue source |
+| ----- | --------- | ---------------------- | ------------------------ | ------------ |
+| 1     | important | Fix sometime emmc upgrade fail.        | Emmc upgrade fail sometime.     | -            |
+
+------
+
+## rk3528_bl32_v1.01.bin
+
+| Date       | File                  | Build commit | Severity |
+| ---------- | :-------------------- | ------------ | -------- |
+| 2023-04-03 | rk3528_bl32_v1.01.bin | c5251becc    | moderate |
+
+### New
+
+1. Add some internal TA interface.
+
+------
+
+## rk3528_bl31_v1.12.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-03-16 | rk3528_bl31_v1.12.elf | 70c5c8d9c    | important |
+
+### New
+
+1. Improve trng performance.
+
+------
+
+## rk3528_ddr_1056MHz_{2L_PCB_}v1.04.bin
+
+| Date       | File                                  | Build commit | Severity  |
+| ---------- | ------------------------------------- | ------------ | --------- |
+| 2023-03-15 | rk3528_ddr_1056MHz_{2L_PCB_}v1.04.bin | dce46ffe73   | important |
+
+### New
+
+1. Add new OTP configurations support.
+
+------
+
+## rk3528_bl31_v1.11.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-03-09 | rk3528_bl31_v1.11.elf | 389e6e47     | important |
+
+### New
+
+1. Modify the ddr configuration flow during system suspend.
+
+------
+
+## rk3528_ddr_1056MHz_{2L_PCB_}v1.03.bin
+
+| Date       | File                                  | Build commit | Severity  |
+| ---------- | ------------------------------------- | ------------ | --------- |
+| 2023-03-09 | rk3528_ddr_1056MHz_{2L_PCB_}v1.03.bin | f0be8490c4   | important |
+
+### New
+
+1. Add support for chips with different OTP configurations.
+
+### Fixed
+
+| Index | Severity  | Update                                                | Issue description                                            | Issue source |
+| ----- | --------- | ----------------------------------------------------- | ------------------------------------------------------------ | ------------ |
+| 1     | important | Fixed LP3 x16 capacity error problem.                 | The ddr capacity anomalies occur when the phy at lp3 x16 mode. | -            |
+| 2     | important | Fixed DDR unstabled when in low frequency(<=400Mhz) . | The kernel will panic when DDR run in low frequency(<=400Mhz). | -            |
+
+------
+
+## rk3528_ddr_1056MHz_{2L_PCB_}v1.02.bin
+
+| Date       | File                                  | Build commit | Severity  |
+| ---------- | ------------------------------------- | ------------ | --------- |
+| 2023-02-15 | rk3528_ddr_1056MHz_{2L_PCB_}v1.02.bin | 60403d388d   | important |
+
+### New
+
+1. Support config derate refresh, per-bank refresh.
+2. Support AXI split.
+3. Enable LP4, LP4X read/write DBI function.
+
+### Fixed
+
+| Index | Severity  | Update                                             | Issue description                              | Issue source |
+| ----- | --------- | -------------------------------------------------- | ---------------------------------------------- | ------------ |
+| 1     | important | Fixed 2L PCB unstabled when DDR in high frequency. | The DDR run in 1056MHz will case system panic. | -            |
+
+------
+
+## rk3528_bl31_v1.10.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-02-15 | rk3528_bl31_v1.10.elf | d74b03e10    | important |
+
+### New
+
+1. Add trng scmi clk support.
+
+------
+
+## rk3528_bl31_v1.09.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-02-03 | rk3528_bl31_v1.09.elf | 16574c7f3    | important |
+
+### New
+
+1. Support all gpio wakeup.
+2. Improve the stability of fiq-debugger.
+
+------
+
+## rk3528_bl31_v1.08.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-01-10 | rk3528_bl31_v1.08.elf | 082486b74    | important |
+
+### New
+
+1. Support crypto/crypto_s/klad clock.
+
+------
+
+## rk3528_bl31_v1.07.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2022-12-26 | rk3528_bl31_v1.07.elf | da191fda0    | important |
+
+### New
+
+1. Support poweroff VDD_LOGIC when system suspend.
+2. Hptimer use soft adjust mode.
+3. Enable PLAT_RK_OPTEED_SYS_CTRL.
+
+------
+
+## rk3528_spl_v1.03.bin
+
+| Date       | File                 | Build commit | Severity |
+| ---------- | :------------------- | ----------- | -------- |
+| 2022-12-14 | rk3528_spl_v1.03.bin | f09ed5ff4f  | important|
+
+### Fixed
+
+| Index | Severity  | Update                 | Issue description                  | Issue source |
+| ----- | --------- | ---------------------- | ---------------------------------- | ------------ |
+| 1     | important | Support HS400ES        | fix HS400 compatibility issues     | -            |
+| 2     | important | config EMMC DS to 1.5X | fix some EMMC compatibility issues | -            |
+
+------
+
+## rk3528_bl31_v1.06.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2022-12-08 | rk3528_bl31_v1.06.elf | 61102ec13    | important |
+
+### New
+
+1. Support USB wakeup.
+
+------
+
+## rk3528_spl_v1.02.bin
+
+| Date       | File                 | Build commit | Severity  |
+| ---------- | :------------------- | ------------ | --------- |
+| 2022-12-02 | rk3528_spl_v1.02.bin | eee09e1f72   | important |
+
+### Fixed
+
+| Index | Severity  | Update                    | Issue description                                            | Issue source |
+| ----- | --------- | ------------------------- | ------------------------------------------------------------ | ------------ |
+| 1     | important | Fix matrix clk rate error | clk_200m：396000 KHz、clk_300m：594000 KHz、clk_339m：264000 KHz. It may influence storage module. | -            |
+
+------
+
+## rk3528_bl31_v1.05.elf
+
+| Date       | File                  | Build commit | Severity |
+| ---------- | :-------------------- | ------------ | -------- |
+| 2022-12-01 | rk3528_bl31_v1.05.elf | b10341386    | moderate |
+
+### New
+
+1. Add TSP clock support.
+
+------
+
+## rk3528_bl31_v1.04.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2022-11-30 | rk3528_bl31_v1.04.elf | 63ba7e8e1    | important |
+
+### New
+
+1. Support HDMI wakeup.
+
+------
+
+## rk3528_{ddr,spl,usbplug}_v1.x.bin
+
+| Date       | File                              | Build commit                                | Severity  |
+| ---------- | :-------------------------------- | ------------------------------------------- | --------- |
+| 2022-11-28 | rk3528_{ddr,spl,usbplug}_v1.x.bin | ddr:0799b9b10a#spl:c52427059#usbplug:4eade6 | important |
+
+### New
+
+1. Initial version.
+
+------
+
+## rk3528_{bl31,bl32,mcu}_v1.x.bin
+
+| Date       | File                            | Build commit                              | Severity  |
+| ---------- | :------------------------------ | ----------------------------------------- | --------- |
+| 2022-11-28 | rk3528_{bl31,bl32,mcu}_v1.x.bin | bl31:a1a47bee6#bl32:3c36a5cb#mcu:76d14059 | important |
+
+### New
+
+1. Initial version.
+
+------
+

--- a/patch-notes/RK3566_EN.md
+++ b/patch-notes/RK3566_EN.md
@@ -1,0 +1,230 @@
+# RK3566 Release Note
+
+## rk3566_ddr_{1056...920}MHz_v1.21.bin
+
+| Date       | File                                 | Build commit | Severity  |
+| ---------- | ------------------------------------ | ------------ | --------- |
+| 2024-01-20 | rk3566_ddr_{1056...920}MHz_v1.21.bin | 2d653b3476   | important |
+
+### Fixed
+
+| Index | Severity  | Update                                                    | Issue description                                            | Issue source |
+| ----- | --------- | --------------------------------------------------------- | ------------------------------------------------------------ | ------------ |
+| 1     | important | Fixed issue that CA training may be missed during reboot. | CA training may not be done during reboot. CA training results always zero. | -            |
+
+------
+
+## rk3568_bl31_ultra_v2.17.elf
+
+| Date       | File                        | Build commit | Severity  |
+| ---------- | --------------------------- | ------------ | --------- |
+| 2024-02-01 | rk3568_bl31_ultra_v2.17.elf | 4a52a1f56    | important |
+
+### New
+
+1. Reduce the maximum uart busy wait time to 5.6ms to prevent long uart busy from causing slow wake up.
+
+------
+
+## rk3566_ddr_1056MHz_ultra_v1.20.bin
+
+| Date       | File                               | Build commit | Severity  |
+| ---------- | ---------------------------------- | ------------ | --------- |
+| 2024-01-13 | rk3566_ddr_1056MHz_ultra_v1.20.bin | 328b43930e   | important |
+
+### New
+
+1. The tRFC value can be configured through ddrbin_tools.
+1. Add read/write vref trining to improve compatibility.
+
+### Fixed
+
+| Index | Severity  | Update                                                    | Issue description                          | Issue source |
+| ----- | --------- | --------------------------------------------------------- | ------------------------------------------ | ------------ |
+| 1     | important | Fixed 6GB LPDDR4 initialization failure problem           | 6GB LPDDR4 panic during DDR initialization | -            |
+| 2     | important | Enable LPDDR4/4X read odt under780M to implove stability. | Some LPDDR4/4X have poor stability at 780M | -            |
+| 3     | important | Fixed issue that CA training may be missed during reboot  | CA training may not be done during reboot  | -            |
+
+------
+
+## rk3566_ddr_{1056...920}MHz_v1.20.bin
+
+| Date       | File                                 | Build commit | Severity  |
+| ---------- | ------------------------------------ | ------------ | --------- |
+| 2024-01-12 | rk3566_ddr_{1056...920}MHz_v1.20.bin | 77170a5e90   | important |
+
+### New
+
+1. The tRFC value can be configured through ddrbin_tools.
+1. Add read write vref trining to improve compatibility.
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                    | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ---------------------------------------------------- | ------------ |
+| 1     | important | Update DDR3/LPDDR3 rd/wr training pattern to improve read and write signal margin | Optimize DDR3/LPDDR3 read and write signal margin    | -            |
+| 2     | important | Fixed 6GB LPDDR3/4 initialization failure problem            | 6GB LPDDR3/4 panic during DDR initialization         | -            |
+| 3     | important | Enable LPDDR4/4X read odt under780M to implove stability.    | Some LPDDR4/4X particles have poor stability at 780M | -            |
+
+------
+
+## rk3568_bl31_ultra_v2.16.elf
+
+| Date       | File                        | Build commit | Severity  |
+| ---------- | --------------------------- | ------------ | --------- |
+| 2023-11-10 | rk3568_bl31_ultra_v2.16.elf | 4af8f9ace    | important |
+
+### New
+
+1. Update the latest code to improve compatibility.
+
+------
+
+## rk3568_bl31_ultra_v2.15.elf
+
+| Date       | File                        | Build commit | Severity  |
+| ---------- | --------------------------- | ------------ | --------- |
+| 2023-10-28 | rk3568_bl31_ultra_v2.15.elf | 2f6f2e6f4    | important |
+
+### New
+
+1. Optimize wakeup speed.
+2. Fix lite mode sleep, vcc_ddr probability high power consumption.
+
+------
+
+## rk3568_bl31_ultra_v2.14.elf
+
+| Date       | File                        | Build commit | Severity  |
+| ---------- | --------------------------- | ------------ | --------- |
+| 2023-10-12 | rk3568_bl31_ultra_v2.14.elf | 7e89dd758    | important |
+
+### New
+
+1. Update the latest code.
+
+------
+
+## rk3566_ddr_1056MHz_ultra_v1.19.bin
+
+| Date       | File                               | Build commit | Severity  |
+| ---------- | ---------------------------------- | ------------ | --------- |
+| 2023-10-07 | rk3566_ddr_1056MHz_ultra_v1.19.bin | b2f397ce2c   | important |
+
+### Warn
+
+1. BL31 should be update to v2.14 or above.
+
+### New
+
+1. Enable derate function for LPDDR4/LPDDR4x.
+2. Add byte mode LPDDR4/4x support.
+
+------
+
+## rk356x_spl_v1.13.bin
+
+| Date       | File                 | Build commit | Severity  |
+| ---------- | -------------------- | ------------ | --------- |
+| 2023-09-25 | rk356x_spl_v1.13.bin | e4e124926e   | important |
+
+### New
+
+1. Print and pass the firmware version number.
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                            | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------ |
+| 1     | important | Solve the issue that the backup image is not loaded when the SPL load or check u-boot.dtb fails | When u-boot.dtb of the first uboot.img is corrupted, SPL doesn't load the backup image. | -            |
+
+------
+
+## rk3566_ddr_{1056...920}MHz_v1.18.bin
+
+| Date       | File                                 | Build commit | Severity  |
+| ---------- | ------------------------------------ | ------------ | --------- |
+| 2023-07-17 | rk3566_ddr_{1056...920}MHz_v1.18.bin | f366f69a7d   | important |
+
+### Fixed
+
+| Index | Severity | Update                                           | Issue description                     | Issue source |
+| ----- | -------- | ------------------------------------------------ | ------------------------------------- | ------------ |
+| 1     | important | Fixed the suspend/resume function crash problem caused by DDR active_ranks configuration error | Suspend/resume function crash | -            |
+
+------
+
+## rk3566_ddr_{1056...324}MHz_v1.17.bin
+
+| Date       | File                                 | Build commit | Severity  |
+| ---------- | ------------------------------------ | ------------ | --------- |
+| 2023-06-20 | rk3566_ddr_{1056...324}MHz_v1.17.bin | 992b933606   | important |
+
+### New
+
+1. Added support for 4rank LPDDR3/LPDDR4/LPDDR4x of different rows.
+2. Enable derate function for LPDDR4/LPDDR4x.
+
+------
+
+## rk3566_ddr_1056MHz_eyescan_v1.16.bin
+
+| Date       | File                                 | Build commit | Severity  |
+| ---------- | :----------------------------------- | ------------ | --------- |
+| 2023-04-19 | rk3566_ddr_1056MHz_eyescan_v1.16.bin | b9c108a4eb   | important |
+
+### New
+
+1. Add RK3566 2D eye scan support.
+
+------
+
+## rk3566_ddr_{1056...324}MHz_v1.16.bin
+
+| Date       | File                                 | Build commit | Severity  |
+| ---------- | ------------------------------------ | ------------ | --------- |
+| 2022-11-16 | rk3566_ddr_{1056...324}MHz_v1.16.bin | 6f71c736ce   | important |
+
+### New
+
+1. RK3568J/RK3568M use 1/2tREFI except LPDDR4/LPDDR4x. LPDDR4/LPDDR4x use derate mode.
+2. TREFI, pageclose configurable by ddrbin tool.
+3. Improve DDR4 performance.
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                            | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------ |
+| 1     | important | To solve the instability problem of some ddr4 when DDR run in 528MHz. | When DDR4 run in 528MHz, the system would unstable, causing a crash and restart | -            |
+| 2     | important | To solve 4GB ECC board Init fail bug                         | 4GB DDR4 board may crash in ddrbin                           |              |
+
+------
+
+## rk3566_ddr_{1056...324}MHz_v1.15.bin
+
+| Date       | File                                 | Build commit | Severity  |
+| ---------- | ------------------------------------ | ------------ | --------- |
+| 2022-11-08 | rk3566_ddr_{1056...324}MHz_v1.15.bin | ec2fae0c96   | important |
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                            | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------ |
+| 1     | important | To solve the instability problem of some chips when DDR run in 324MHz. | When DDR run in 324MHz, the system would unstable, causing a crash and restart | -            |
+
+------
+
+## rk3566_ddr_{1056...324}MHz_v1.14.bin
+
+| Date       | File                                 | Build commit | Severity  |
+| ---------- | :----------------------------------- | ------------ | --------- |
+| 2022-08-27 | rk3566_ddr_{1056...324}MHz_v1.14.bin | b1f29a2a6f   | important |
+
+### Fixed
+
+| Index | Severity  | Update                                                    | Issue description                                            | Issue source |
+| ----- | --------- | --------------------------------------------------------- | ------------------------------------------------------------ | ------------ |
+| 1     | moderate  | fix Fix set of t_xs_x32, t_xs_abort_x32 and t_xs_fast_x32 | Fix set of t_xs_x32, t_xs_abort_x32 and t_xs_fast_x32.This bug may lead to some low density dram(128M) fail. | -         |
+| 2     | important | fix ddr4 528M stability problem                           | some DRAM DLL can't lock at 528M，DLL should be bypass for 528M | -         |
+
+------

--- a/patch-notes/RK3568_EN.md
+++ b/patch-notes/RK3568_EN.md
@@ -1,0 +1,474 @@
+# RK3568 Release Note
+
+## rk3568_ddr_{1560...920}MHz_v1.21.bin
+
+| Date       | File                                 | Build commit | Severity  |
+| ---------- | ------------------------------------ | ------------ | --------- |
+| 2024-01-20 | rk3568_ddr_{1560...920}MHz_v1.21.bin | 2d653b3476   | important |
+
+### Fixed
+
+| Index | Severity  | Update                                                    | Issue description                                            | Issue source |
+| ----- | --------- | --------------------------------------------------------- | ------------------------------------------------------------ | ------------ |
+| 1     | important | Fixed issue that CA training may be missed during reboot. | CA training may not be done during reboot. CA training results always zero. | -            |
+
+------
+
+## rk3568_ddr_{1560...920}MHz_v1.20.bin
+
+| Date       | File                                 | Build commit | Severity  |
+| ---------- | ------------------------------------ | ------------ | --------- |
+| 2024-01-12 | rk3568_ddr_{1560...920}MHz_v1.20.bin | 77170a5e90   | important |
+
+### New
+
+1. The tRFC value can be configured through ddrbin_tools.
+1. Add read write vref trining to improve compatibility.
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                            | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------ |
+| 1     | important | When DDR ECC is enabled, CPU early access is used to ensure the ECC correctness of the pstore segment memory after restart. | When DDR ECC is enabled, the pstore information is lost after restarting. | -            |
+| 2     | important | Update DDR3/LPDDR3 rd/wr training pattern to improve read and write signal margin | Optimize DDR3/LPDDR3 read and write signal margin            | -            |
+| 3     | important | Fixed 6GB LPDDR3/4 initialization failure problem            | 6GB LPDDR3/4 panic during DDR initialization                 | -            |
+| 4     | important | Enable LPDDR4/4X read odt under780M to implove stability.    | Some LPDDR4/4X particles have poor stability at 780M         | -            |
+
+------
+
+## rk3568_pcie_v2.10.bin
+
+| Date       | File                  | Build commit | Severity |
+| ---------- | --------------------- | ------------ | -------- |
+| 2023-12-18 | rk3568_pcie_v2.10.bin | 35f57cde3    | moderate |
+
+### New
+
+1. Update the version.
+
+------
+
+## rk3568_pcie_v2.00.bin
+
+| Date       | File                  | Build commit | Severity |
+| ---------- | --------------------- | ------------ | -------- |
+| 2023-12-06 | rk3568_pcie_v2.00.bin | I3e280b78    | moderate |
+
+### New
+
+1. Fix bar capacity.
+
+------
+
+## rk3568_bl31_rt_v1.02.elf
+
+| Date       | File                     | Build commit | Severity |
+| ---------- | ------------------------ | ------------ | -------- |
+| 2023-11-02 | rk3568_bl31_rt_v1.02.elf | 30c17915b    | moderate |
+
+### New
+
+1. Support config l3 partition according to atags.
+
+------
+
+## rk3568_pcie_v1.00.bin
+
+| Date       | File                  | Build commit | Severity |
+| ---------- | --------------------- | ------------ | -------- |
+| 2023-10-07 | rk3568_pcie_v1.00.bin | I01c2c7d7    | moderate |
+### New
+
+1. Add bare system executable firmware that supports PCIe EP initialization.
+
+------
+
+## rk3568_ddr_{1560...920}MHz_v1.19.bin
+
+| Date       | File                                 | Build commit | Severity  |
+| ---------- | ------------------------------------ | ------------ | --------- |
+| 2023-09-11 | rk3568_ddr_{1560...920}MHz_v1.19.bin | fdeec6f4fc   | important |
+
+### New
+
+1. Support RK3567.
+2. RK3568 support LVDS1.
+
+------
+
+## rk3568_bl31_v1.44.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | --------------------- | ------------ | --------- |
+| 2023-09-19 | rk3568_bl31_v1.44.elf | 8cea6ab0b    | important |
+
+### New
+
+1. Add support for RK3567 SoC.
+
+------
+
+## rk356x_spl_v1.13.bin
+
+| Date       | File                 | Build commit | Severity  |
+| ---------- | :------------------- | ------------ | --------- |
+| 2023-09-25 | rk356x_spl_v1.13.bin | e4e124926e   | important |
+
+### New
+
+1.  Print and pass the firmware version number.
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                            | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------ |
+| 1     | important | Solve the issue that the backup image is not loaded when the SPL load or check u-boot.dtb fails | When u-boot.dtb of the first uboot.img is corrupted, SPL doesn't load the backup image. | -            |
+
+------
+
+## rk3568_bl32_v2.11.bin
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-08-28 | rk3568_bl32_v2.11.bin | b5340fd65    | important |
+
+### New
+
+1.  Pseudo random number seed will be set by default.
+2. Supports read and write security flag interfaces.
+3. Support check ta encryption key is written.
+4. Supports the tokbrick ksn interface.
+
+### Fixed
+
+| Index | Severity  | Update                                               | Issue description                                 | Issue source |
+| ----- | --------- | ---------------------------------------------------- | ------------------------------------------------- | ------------ |
+| 1     | important | Fixed hardware crypto check supported algorithm list | Error will be reported when using hardware crypto | -            |
+
+------
+
+## rk3568_bl31_cpu3_v1.01.elf
+
+| Date       | File                              | Build commit | Severity |
+| ---------- | --------------------------------- | ------------ | -------- |
+| 2023-08-04 | rk3568_bl31_cpu3_v1.01.elf | b3d2ce25a    | moderate |
+
+### New
+
+1. Support CPU3 startup based on the latest bl31 code.
+
+------
+
+## rk3568_ddr_{1560...920}MHz_v1.18.bin
+
+| Date       | File                                 | Build commit | Severity  |
+| ---------- | ------------------------------------ | ------------ | --------- |
+| 2023-07-17 | rk3568_ddr_{1560...920}MHz_v1.18.bin | f366f69a7d   | important |
+
+### Fixed
+
+| Index | Severity | Update                                           | Issue description                     | Issue source |
+| ----- | -------- | ------------------------------------------------ | ------------------------------------- | ------------ |
+| 1     | important | Fixed the suspend/resume function crash problem caused by DDR active_ranks configuration error | Suspend/resume function crash | -            |
+
+------
+
+## rk3568_bl31_l3_part_ecc_v1.00.elf
+
+| Date       | File                              | Build commit | Severity |
+| ---------- | --------------------------------- | ------------ | -------- |
+| 2023-06-20 | rk3568_bl31_l3_part_ecc_v1.00.elf | 6f31c2d8c    | moderate |
+
+### New
+
+1. Add initial version: support L3 cache partition and cache ecc.
+
+------
+
+## rk3568_ddr_{1056...324}MHz_v1.17.bin
+
+| Date       | File                                 | Build commit | Severity  |
+| ---------- | ------------------------------------ | ------------ | --------- |
+| 2023-06-20 | rk3568_ddr_{1056...324}MHz_v1.17.bin | 992b933606   | important |
+
+### New
+
+1. Added support for 4rank LPDDR3/LPDDR4/LPDDR4x of different rows.
+2. Add DDR ECC poison function support.
+3. Enable derate function for LPDDR4/LPDDR4x.
+4. Add pstore support when ECC enabled.
+
+------
+
+## rk3568_bl32_v2.10.bin
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-06-07 | rk3568_bl32_v2.10.bin | dcfdd61d0    | important |
+
+### New
+
+1. Support recovery from OTP backup data after critical OTP data reading errors.
+2. Added the address parameter security check for crypto_service.
+2. Kernel support read secure boot flag and public key hash.
+3. Support dynamic shared memory, and the secure and normal world can transfer more larger data.
+4. BL32 supports pstore, and the kernel can view print info of BL32 through pstore node.
+
+------
+
+## rk3568_bl31_v1.43.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | --------------------- | ------------ | --------- |
+| 2023-06-05 | rk3568_bl31_v1.43.elf | bf602aff1    | important |
+
+### Fixed
+
+| Index | Severity  | Update                                           | Issue description                     | Issue source |
+| ----- | --------  | ------------------------------------------------ | ------------------------------------- | ------------ |
+| 1     | important | Fix deadlock for cpuidle when enter bl31  | The system freezes for a while and then return to normal | -   |
+
+------
+
+## rk3568_bl31_rt_v1.01.elf
+
+| Date       | File                     | Build commit | Severity |
+| ---------- | ------------------------ | ------------ | -------- |
+| 2023-05-11 | rk3568_bl31_rt_v1.01.elf | b28ca126a    | moderate |
+
+### New
+
+1. Support adjust pvtpll config by OTP.
+2. Adjust default pvtpll config for stability.
+
+------
+
+## rk3568_bl31_v1.42.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | --------------------- | ------------ | --------- |
+| 2023-05-11 | rk3568_bl31_v1.42.elf | 7f859117f    | important |
+
+### New
+
+1. Support adjust pvtpll config by OTP.
+2. Adjust default pvtpll config for stability.
+
+------
+
+## rk3568_bl31_v1.41.elf
+
+| Date       | File                  | Build commit | Severity |
+| ---------- | --------------------- | ------------ | -------- |
+| 2023-05-06 | rk3568_bl31_v1.41.elf | e24c3f77b    | moderate |
+
+### Fixed
+
+| Index | Severity | Update                                           | Issue description                     | Issue source |
+| ----- | -------- | ------------------------------------------------ | ------------------------------------- | ------------ |
+| 1     | moderate | Change smc_handler ID of DDR ECC poison function | The DDR ECC poison function exception | -            |
+
+------
+
+## rk3568_bl31_rt_v1.00.elf
+
+| Date       | File                     | Build commit | Severity |
+| ---------- | ------------------------ | ------------ | -------- |
+| 2023-05-04 | rk3568_bl31_rt_v1.00.elf | c3f2c8c3a    | moderate |
+
+### New
+
+1. Optimize RT Latency.
+
+------
+
+## rk3568_ddr_1560MHz_eyescan_v1.16.bin
+
+| Date       | File                                 | Build commit | Severity  |
+| ---------- | :----------------------------------- | ------------ | --------- |
+| 2023-04-19 | rk3568_ddr_1560MHz_eyescan_v1.16.bin | b9c108a4eb   | important |
+
+### New
+
+1. Add RK3568 2D eye scan support.
+
+------
+
+## rk3568_bl31_v1.40.elf
+
+| Date       | File                  | Build commit | Severity |
+| ---------- | --------------------- | ------------ | -------- |
+| 2023-04-19 | rk3568_bl31_v1.40.elf | aef7950e4    | moderate |
+
+### New
+
+1. Add DDR ECC poison support.
+
+------
+
+## rk356x_usbplug_v1.17.bin
+
+| Date       | File                     | Build commit | Severity |
+| ---------- | :----------------------- | ------------ | -------- |
+| 2023-04-14 | rk356x_usbplug_v1.17.bin | 0661d5       | moderate |
+
+### New
+
+1. Support more spiflash.
+
+------
+
+## rk3568_bl31_v1.39.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | --------------------- | ------------ | --------- |
+| 2023-04-13 | rk3568_bl31_v1.39.elf | 0d745c7b1    | important |
+
+### New
+
+1. Improve the stability of otp.
+
+------
+
+## rk3568_ddr_{1056...324}MHz_v1.16.bin
+
+| Date       | File                                 | Build commit | Severity  |
+| ---------- | ------------------------------------ | ------------ | --------- |
+| 2023-02-26 | rk3568_ddr_{1056...324}MHz_v1.16.bin | 6f71c736ce   | important |
+
+### New
+
+1. RK3568J/RK3568M use 1/2tREFI except LPDDR4/LPDDR4x. LPDDR4/LPDDR4x use derate mode.
+2. TREFI, pageclose configurable by ddrbin tool.
+3. Improve DDR4 performance.
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                            | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------ |
+| 1     | important | To solve the instability problem of some ddr4 when DDR run in 528MHz. | When DDR4 run in 528MHz, the system would unstable, causing a crash and restart | -            |
+| 2     | important | To solve 4GB ECC board Init fail bug                         | 4GB DDR4 board may crash in ddrbin                           |              |
+
+------
+
+## rk3568_bl31_v1.38.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | --------------------- | ------------ | --------- |
+| 2023-02-16 | rk3568_bl31_v1.38.elf | 94b2d40dc    | important |
+
+### New
+
+1. Improve the stability of sdei.
+
+------
+
+## rk3568_bl31_v1.37.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | --------------------- | ------------ | --------- |
+| 2023-02-02 | rk3568_bl31_v1.37.elf | 1cd72fefa    | important |
+
+### New
+
+1. Enable sdei.
+2. Support config l3 partition according to atags.
+
+------
+
+## rk3568_ddr_{1560...324}MHz_v1.15.bin
+
+| Date       | File                                 | Build commit | Severity  |
+| ---------- | ------------------------------------ | ------------ | --------- |
+| 2022-11-08 | rk3568_ddr_{1560...324}MHz_v1.15.bin | ec2fae0c96   | important |
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                            | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------ |
+| 1     | important | To solve the instability problem of some chips when DDR run in 324MHz. | When DDR run in 324MHz, the system would unstable, causing a crash and restart | -            |
+
+------
+
+## rk3568_bl31_v1.36.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | --------------------- | ------------ | --------- |
+| 2022-11-08 | rk3568_bl31_v1.36.elf | 2c8be93f9    | important |
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                            | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------ |
+| 1     | important | To solve the instability problem of some chips when DDR run in 324MHz. | When DDR run in 324MHz, the system would unstable, causing a crash and restart | -            |
+
+------
+
+## rk356x_usbplug_v1.16.bin
+
+| Date       | File                     | Build commit | Severity |
+| ---------- | :----------------------- | ------------ | -------- |
+| 2022-11-02 | rk356x_usbplug_v1.16.bin | eaaeb1       | moderate |
+
+### New
+
+1. Support more spiflash.
+
+------
+
+## rk3568_bl31_v1.35.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2022-10-24 | rk3568_bl31_v1.35.elf | cddd6f52e    | important |
+
+### Fixed
+
+| Index | Severity  | Update                                                    | Issue description                                            | Issue source |
+| ----- | --------- | --------------------------------------------------------- | ------------------------------------------------------------ | ------------ |
+| 1     | important | fix the suspend/resume stability problem, the PCIE suspend fail. | Linux kernel doesn't save/restore GICR, so we need do it if vdd_logic is off in suspend. | -         |
+
+------
+
+## rk356{x_usbplug, 8_miniloader_spinand}_v1.15.bin
+
+| Date       | File                                             | Build commit | Severity |
+| ---------- | :----------------------------------------------- | ------------ | -------- |
+| 2022-09-26 | rk356{x_usbplug, 8_miniloader_spinand}_v1.15.bin | 65048d1      | moderate |
+
+### New
+
+1. Support more spiflash.
+
+------
+
+## rk3568_bl32_v2.09.bin
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2022-09-16 | rk3568_bl32_v2.09.bin | d84087907    | important |
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                            | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------ |
+| 1     | important | Solve the problem that OPTEE is stuck during startup when printing is closed | User use /rkbin/tools/ddrbin_tool to close printing ,  then rk_atags will notify OPTEE to disable printing, When OPTEE starts, it will be stuck and unable to enter U-Boot | -            |
+
+------
+
+## rk3568_ddr_{1560...324}MHz_v1.14.bin
+
+| Date       | File                                 | Build commit | Severity  |
+| ---------- | :----------------------------------- | ------------ | --------- |
+| 2022-08-27 | rk3568_ddr_{1560...324}MHz_v1.14.bin | b1f29a2a6f   | important |
+
+### Fixed
+
+| Index | Severity  | Update                                                    | Issue description                                            | Issue source |
+| ----- | --------- | --------------------------------------------------------- | ------------------------------------------------------------ | ------------ |
+| 1     | important | fix some LPDDR4 stability problem                         | CXMT CXDB5CCAM-MK instability for 1560MHz at LPDDR4 mode. Fix this issue by set CLK/CA slew rate from 0xf  to 0x0 . | -         |
+| 2     | moderate  | fix Fix set of t_xs_x32, t_xs_abort_x32 and t_xs_fast_x32 | Fix set of t_xs_x32, t_xs_abort_x32 and t_xs_fast_x32.This bug may lead to some low density dram(128M) fail. | -         |
+| 3     | important | fix ddr4 528M stability problem                           | some DRAM DLL can't lock at 528M，DLL should be bypass for 528M | -         |
+|       | important | fix ddr4 1560M stability problem                          | some 2 rank DDR4 PCB DQS/DQ slew rate should be set to 0x0 when running at1560MHz. | -         |
+
+------

--- a/patch-notes/RK3588_EN.md
+++ b/patch-notes/RK3588_EN.md
@@ -1,0 +1,581 @@
+# RK3588 Release Note
+
+## rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.16.bin
+
+| Date       | File                                         | Build commit | Severity  |
+| ---------- | :------------------------------------------- | ------------ | --------- |
+| 2024-02-04 | rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.16.bin | 9fffbe1e78   | important |
+
+### New
+
+1. Modify the LPDDR5 frequency to improve stability.
+2. Add support dram with CS0 capacity less than CS1 capacity.
+3. Modify the DERATEINT.mr4_read_interval configuration.
+
+### Fixed
+
+| Index | Severity  | Update                                      | Issue description                                            | Issue source |
+| ----- | --------- | ------------------------------------------- | ------------------------------------------------------------ | ------------ |
+| 1     | important | Fixed derate issue with LPDDR5 of one rank. | Maybe hang in kernel when switch the frequency for LPDDR5 of one rank. | -            |
+
+------
+
+## rk3588_bl31_v1.45.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-12-27 | rk3588_bl31_v1.45.elf | 4ca8a8422    | important |
+
+### New
+
+1. Optimize the time of DFS atfter system resume.
+2. Cpu switch to hight frequency when systeme resume.
+3. Support config pvtpll parameters by sip.
+
+------
+
+## rk3588_pcie_v2.10.bin
+
+| Date       | File                  | Build commit | Severity |
+| ---------- | --------------------- | ------------ | -------- |
+| 2023-12-18 | rk3588_pcie_v2.10.bin | 35f57cde3    | moderate |
+
+### New
+
+1. Update the version.
+
+------
+
+## rk3588_pcie_v2.00.bin
+
+| Date       | File                  | Build commit | Severity |
+| ---------- | --------------------- | ------------ | -------- |
+| 2023-12-06 | rk3588_pcie_v2.00.bin | I3e280b78    | moderate |
+
+### New
+
+1. Fix bar capacity.
+
+------
+
+## rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.15.bin
+
+| Date       | File                                         | Build commit | Severity  |
+| ---------- | :------------------------------------------- | ------------ | --------- |
+| 2023-11-23 | rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.15.bin | d5483af87d   | important |
+
+### New
+
+1. Avoid PHY skew value greater than dll lock value，improve the stability for 528MHz.
+2. Fix the data training process，improve the stability.
+3. Resume ZQ background calibration for LPDDR5.
+
+------
+
+## rk3588_usbplug_v1.11.bin
+
+| Date       | File                     | Build commit | Severity  |
+| ---------- | :----------------------- | ------------ | --------- |
+| 2023-11-20 | rk3588_usbplug_v1.11.bin | dcac518e7    | important |
+
+### New
+
+1. Add rk3583 upgrade support.
+
+------
+
+## rk3583_ddr_lp4_1848MHz_lp5_2112MHz_v1.14.bin
+
+| Date       | File                                         | Build commit | Severity  |
+| ---------- | :------------------------------------------- | ------------ | --------- |
+| 2023-11-10 | rk3583_ddr_lp4_1848MHz_lp5_2112MHz_v1.14.bin | 73dffea49e   | important |
+
+### New
+
+1. Add RK3583 support.
+
+------
+
+## rk3588_bl31_v1.44.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-11-07 | rk3588_bl31_v1.44.elf | 4acbe711b    | important |
+
+### New
+
+1. Add pvtpll support rk3583.
+2. Add support to read secure otp.
+3. Optimize the time of dmc restore.
+
+------
+
+## rk3588_pcie_v1.00.bin
+
+| Date       | File                  | Build commit | Severity |
+| ---------- | --------------------- | ------------ | -------- |
+| 2023-10-07 | rk3588_pcie_v1.00.bin | I01c2c7d7    | moderate |
+
+### New
+
+1. Add bare system executable firmware that supports PCIe EP initialization.
+
+------
+
+## rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.14.bin
+
+| Date       | File                                         | Build commit | Severity  |
+| ---------- | :------------------------------------------- | ------------ | --------- |
+| 2023-09-26 | rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.14.bin | 73dffea49e   | important |
+
+### New
+
+1. Improve the stability of LPDDR5.
+2. Add fwver support.
+
+------
+
+## rk3588_bl32_v1.15.bin
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-09-25 | rk3588_bl32_v1.15.bin | 62aa10b7     | important |
+
+### New
+
+1.  Support print firmware version, and support transmit firmware version to subsequent firmware.
+
+------
+
+## rk3588_bl31_v1.43.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-09-26 | rk3588_bl31_v1.43.elf | 24b7dd41a    | important |
+
+### New
+
+1. Supports to pass bl31 version number through rk atags.
+2. Support to configure wake sources for virtual-poweroff through dts.
+
+------
+
+## rk3588_spl_v1.13.bin
+
+| Date       | File                 | Build commit | Severity  |
+| ---------- | :------------------- | ------------ | --------- |
+| 2023-09-25 | rk3588_spl_v1.13.bin | e4e124926e   | important |
+
+### New
+
+1. Print and pass the firmware version number.
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                            | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------ |
+| 1     | important | Solve the issue that the backup image is not loaded when the SPL load or check u-boot.dtb fails | When u-boot.dtb of the first uboot.img is corrupted, SPL doesn't load the backup image. | -            |
+------
+
+## rk3588_bl31_v1.42.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-09-09 | rk3588_bl31_v1.42.elf | 87bcc5dfe    | important |
+
+### New
+
+1. Optimize the time of system resume.
+2. Support any cpu to do system suspend/resume.
+3. Support all pwm int to wakeup when virtual-poweroff.
+
+------
+
+## rk3588_bl32_v1.14.bin
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-08-28 | rk3588_bl32_v1.14.bin | b5340fd65    | important |
+
+### New
+
+1.  Pseudo random number seed will be set by default.
+2.  Supports read and write security flag interfaces.
+3.  Support check ta encryption key is written.
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                 | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ------------------------------------------------- | ------------ |
+| 1     | important | Fixed hardware crypto probability crash issue after enabling dynamic memory | Error will be reported when using hardware crypto | -            |
+
+------
+
+## rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.13.bin
+
+| Date       | File                                         | Build commit | Severity  |
+| ---------- | :------------------------------------------- | ------------ | --------- |
+| 2023-08-11 | rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.13.bin | 25cee80c4f   | important |
+
+### Warn
+
+1. BL31 should be update to V1.41 or above.
+
+### New
+
+1. Improve the stability of LPDDR5 528MHz.
+2. Update vref_inner for each channel in fsp_param to improve stability.
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                         | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | --------------------------------------------------------- | ------------ |
+| 1     | important | Fixed init fail issue that boot in high temperature environment | Panic in ddrbin when boot in high temperature environment | -            |
+
+------
+
+## rk3588_bl31_v1.41.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-08-10 | rk3588_bl31_v1.41.elf | b7c5102a2    | important |
+
+### New
+
+1. Support L3 partition.
+2. Update configuration of ddr vref_inner.
+3. Support to config MCU sleep parameter through DTS.
+
+------
+
+## rk3588_bl31_v1.40.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-07-13 | rk3588_bl31_v1.40.elf | dc1125f48    | important |
+
+### New
+
+1. Add support to reset vop sub mem pd.
+
+------
+
+## rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.12.bin
+
+| Date       | File                                         | Build commit | Severity  |
+| ---------- | :------------------------------------------- | ------------ | --------- |
+| 2023-07-06 | rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.12.bin | 52218f4949   | important |
+
+### New
+
+1. Add support print training result and mr value.
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                            | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------ |
+| 1     | important | Fixed init fail issue that max freq between 1066-1600MHz     | Panic in ddrbin when max DDR freq between 1066-1600MHz.      | -            |
+| 2     | important | Fixed the issue painc in ddrbin caused by multiple initialization of DDR | When the first SPL firmware failed to load, reloading the second firmware would result in repeated initialization of the DDR. This caused a panic in ddrbin. | -            |
+
+------
+
+## rk3588_bl31_v1.39.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-06-27 | rk3588_bl31_v1.39.elf | 001b4889e    | important |
+
+### New
+
+1. Change read size to 128 bytes.
+2. Adjust pvtpll table by otp.
+3. Modify pvtpll table for rk3588j/m.
+
+------
+
+## rk3588_bl31_v1.38.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-05-09 | rk3588_bl31_v1.38.elf | 3389cfdda    | important |
+
+### Warn
+
+1. DDR bin should be update to V1.11 or above.
+
+### New
+
+1. Update configuration of ddr lp5 mr.
+2. Improve the stability of hdmirx.
+3. Support ddr spread spectrum mode.
+
+------
+
+## rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.11.bin
+
+| Date       | File                                         | Build commit | Severity  |
+| ---------- | :------------------------------------------- | ------------ | --------- |
+| 2023-05-09 | rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.11.bin | f1474cf52f   | important |
+
+### Warn
+
+1. BL31 should be update to V1.38 or above.
+
+### New
+
+1. Added more print info when initialization fails to help locate soldering issues.
+2. Optimizing boot time.
+3. Enable per bank refresh function.
+4. LPDDR5 4 channels use different write vref values to improve stability.
+5. First init LPDDR4x.
+6. LPDDR5 cavref update to 36%.
+7. Add support spread spectrum mode.
+
+------
+
+## rk3588_bl32_v1.13.bin
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-04-19 | rk3588_bl32_v1.13.bin | 7f1ea6d6e    | important |
+
+### New
+
+1. OTP supports burst read to accelerate BL32 startup speed.
+2. Kernel support read secure boot flag and public key hash.
+3. Support dynamic shared memory, and the secure and normal world can transfer more larger data.
+4. BL32 supports pstore, and the kernel can view print info of BL32 through pstore node.
+
+------
+
+## rk3588_bl31_v1.37.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-03-08 | rk3588_bl31_v1.37.elf | 9609b9c19    | important |
+
+### New
+
+1. Save/restore u2phy_grf registers when system suspend/resume.
+2. Save/restore more ddr related registers when system suspend/resume.
+3. Compatible with system suspend/resume in QNX.
+
+------
+
+## rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.10.bin
+
+| Date       | File                                         | Build commit | Severity  |
+| ---------- | :------------------------------------------- | ------------ | --------- |
+| 2022-11-21 | rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.10.bin | 75d050770f   | important |
+
+### New
+
+1. Pageclose can be enable/disable by ddrbin_tool.
+
+### Fixed
+
+| Index | Severity  | Update                       | Issue description                                            | Issue source |
+| ----- | --------- | ---------------------------- | ------------------------------------------------------------ | ------------ |
+| 1     | important | fix total 24GB bug           | If the DDR total capacity is 24GB, it will be stuck and unable to enter kernel. | -            |
+| 2     | important | fix LP4/LP4X stability issue | Some LP4/LP4X board need to update read odt to 40ohm to fix stability issue. Note: BL31 should be update to V1.37. | -            |
+| 3     | important | improve LP5 performance      | LPDDR5 timing tWTR  calculate error lead to slow performance | -            |
+
+------
+
+## rk3588_bl31_v1.36.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-01-30 | rk3588_bl31_v1.36.elf | 78ee25fe7    | important |
+
+### New
+
+1. Supports analyze infrared signals of various protocols during system suspend by software, which needs to be used together with mcu.
+
+------
+
+## rk3588_bl31_v1.35.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-01-16 | rk3588_bl31_v1.35.elf | bd7bac37a    | important |
+
+### New
+
+1. Improve the stability of hdmirx.
+
+------
+
+## rk3588_bl31_v1.34.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2023-01-10 | rk3588_bl31_v1.34.elf | e63a16361    | important |
+
+### New
+
+1. Support hptimer to use soft adjust mode.
+2. Support pvtpll to add length.
+
+### Fixed
+
+| Index | Severity  | Update                                                | Issue description                                            | Issue source |
+| ----- | --------- | ----------------------------------------------------- | ------------------------------------------------------------ | ------------ |
+| 1     | important | Avoid pmu mcu to boot accidentally in system suspend. | With pmu mcu's accidental boot, linux kernel's code and data may be overwrite after system resume. | -            |
+
+------
+
+## rk3588_spl_v1.12.bin
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2022-12-26 | rk3588_spl_v1.12.bin  | 5f53abfa     | important |
+
+### New
+
+1. Support SPL AB.
+
+------
+
+## rk3588_bl31_v1.33.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2022-12-07 | rk3588_bl31_v1.33.elf | 17b41886e    | important |
+
+### New
+
+1. Support rk3588m, rk3588j.
+
+------
+
+## rk3588_usbplug_v1.10.bin
+
+| Date       | File                     | Build commit | Severity  |
+| ---------- | :----------------------- | ------------ | --------- |
+| 2022-11-22 | rk3588_usbplug_v1.10.bin | b0e3c43c2    | important |
+
+### New
+
+1. Improve compatibility.
+
+------
+
+## rk3588_bl31_v1.32.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2022-11-21 | rk3588_bl31_v1.32.elf | e529a2760    | important |
+
+### New
+
+1. Support bus auto CS.
+
+------
+
+## rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.09.bin
+
+| Date       | File                                         | Build commit | Severity  |
+| ---------- | :------------------------------------------- | ------------ | --------- |
+| 2022-11-21 | rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.09.bin | a930779e06   | important |
+
+### New
+
+1. Derate/perbank refresh can be enable/disable by ddrbin_tool.
+2. Support pstore function.
+3. Boot FSP configurable by ddrbin_tool.
+4. Enable LPDDR5 DMC function.
+5. Support LPDDR5 byte mode DRAM.
+6. Recycle 256MB memory(overlap with REG space). This function can be disable by ddrbin_tool.
+
+### Fixed
+
+| Index | Severity  | Update                                   | Issue description                                            | Issue source |
+| ----- | --------- | ---------------------------------------- | ------------------------------------------------------------ | ------------ |
+| 1     | important | Fix WRTRN Bug                            | Fix WRTRN bug when ddr freq between 533MHz - 1066MHz         | -            |
+| 2     | important | Fix ZQCALIB bug                          | Increase auto ZQCALIB command period to 470ms                | -            |
+| 3     | important | Fix 528M bug                             | 528MHz undo RDTRN, SW*skew should be clean before clean before switch to 528MHz. | -            |
+| 4     | important | Improve LPDDR5 stability and performance | Fix some LPDDR5 timing like rd2wr,wr2rd and hash config to improve stability and performance. | -            |
+| 5     | important | LP4/LP4x support 32GB cap                | LP4/LP4x support 32GB cap                                    | -            |
+
+------
+
+## rk3588_bl31_v1.31.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2022-11-09 | rk3588_bl31_v1.31.elf | 91e396185    | important |
+
+### New
+
+1. Enable RK_ENABLE_A76_L2_FLUSH_TO_L3 function.
+2. Support amp function.
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ----------------- | ------------ |
+| 1     | important | Save/restore some performance setting in system suspend/resume | -                 | -            |
+
+------
+
+## rk3588_bl31_v1.30.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2022-10-12 | rk3588_bl31_v1.30.elf | 1450d21e8    | important |
+
+### New
+
+1. Support pstore.
+
+------
+
+## rk3588_bl31_v1.29.elf
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ----------- | --------- |
+| 2022-09-29 | rk3588_bl31_v1.29.elf | 686b5c48b   | important |
+
+### New
+
+1. Add A55 AT speculative patches.
+2. Add LPDDR5 DFS patches, support DFS between rows.
+3. Config FW-DSU region according to the specific DDR channel.
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                            | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------ |
+| 1     | important | Fix problem about CEC wakeup.                  | When waiting for CEC wakeup source in system suspend, gpio1/3 irq will wakeup both AP and mcu . | -        |
+| 2     | important | Fix configuration about ddr.                   | Fix ddr-unstable problem.                                    | -        |
+| 3     | important | Fix problem in system suspend if disable uart. | If loader disable uart, system suspend will panic.           | -        |
+
+------
+
+## rk3588_bl32_v1.12.bin
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2022-09-20 | rk3588_bl32_v1.12.bin | 4542e1efd    | important |
+
+### New
+
+1. Config FW-DSU region according to the specific DDR channel.
+
+------
+
+## rk3588_bl32_v1.11.bin
+
+| Date       | File                  | Build commit | Severity  |
+| ---------- | :-------------------- | ------------ | --------- |
+| 2022-09-15 | rk3588_bl32_v1.11.bin | d84087907    | important |
+
+### Fixed
+
+| Index | Severity  | Update                                                       | Issue description                                            | Issue source |
+| ----- | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------ |
+| 1     | important | Solve the problem that OPTEE is stuck during startup when printing is closed | User use /rkbin/tools/ddrbin_tool to close printing ,  then rk_atags will notify OPTEE to disable printing, When OPTEE starts, it will be stuck and unable to enter U-Boot | -            |
+
+------
+


### PR DESCRIPTION
This PR adds official patch notes from Rockchip (https://github.com/rockchip-linux/rkbin/tree/master/doc/release) for the following SoCs:

- RK3399
- RK3528
- RK3566
- RK3568
- RK3588

They can be helpful to check if updated binary blobs could solve some issues or are incompatible with earlier BL31/DDR blobs.